### PR TITLE
Fixed error in Container Scan Action and updated NGINX base image to secure version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ secrets.DOCKER_HUB_USERNAME }}/sprint-name-generator
+      # See https://github.com/Azure/container-scan/issues/146
+      DOCKLE_HOST: "unix:///var/run/docker.sock"
       
     steps:
 
@@ -61,11 +63,10 @@ jobs:
     - name: Build Docker image
       run: docker build . -f ${{ github.workspace }}/build/package/Dockerfile -t ${{ env.IMAGE_NAME }}:${{github.run_number}} -t ${{ env.IMAGE_NAME }}:latest
 
-# Seems to always fail with 'unknown manifest', as if it couldn't access the image that was built in the step before - future me problem
     - name: Run container image security scan
       uses: Azure/container-scan@v0.1
       with:
-        image-name: ${{ env.IMAGE_NAME }}:latest
+        image-name: ${{ env.IMAGE_NAME }}:${{github.run_number}}
         severity-threshold: CRITICAL
         run-quality-checks: true
         

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,4 +81,3 @@ jobs:
       with:
         branch: gh-pages
         folder: ${{ github.workspace }}/web/build
-      if: ${{ false }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Run container image security scan
       uses: Azure/container-scan@v0
       with:
-        image-name: ${{ env.IMAGE_NAME }}:${{github.run_number}}
+        image-name: ${{ env.IMAGE_NAME }}:latest
         severity-threshold: CRITICAL
         run-quality-checks: true
         

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
 
 # Seems to always fail with 'unknown manifest', as if it couldn't access the image that was built in the step before - future me problem
     - name: Run container image security scan
-      uses: Azure/container-scan@v0
+      uses: Azure/container-scan@v0.1
       with:
         image-name: ${{ env.IMAGE_NAME }}:latest
         severity-threshold: CRITICAL

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Run container image security scan
       uses: Azure/container-scan@v0
       with:
-        image-name: ${{ env.IMAGE_NAME }}
+        image-name: ${{ env.IMAGE_NAME }}:${{github.run_number}}
         severity-threshold: CRITICAL
         run-quality-checks: true
         

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,7 +75,6 @@ jobs:
       uses: webfactory/ssh-agent@v0.4.1
       with:
         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
-      if: ${{ false }}
 
     - name: Deploy Page
       uses: JamesIves/github-pages-deploy-action@releases/v3
@@ -83,4 +82,3 @@ jobs:
         SSH: true
         BRANCH: gh-pages
         FOLDER: ${{ github.workspace }}/web/build
-      if: ${{ false }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ docker build -t sprint-name-generator -f build/package/Dockerfile .
 
 ### Run latest image from Docker Hub
 ``` bash
-
+docker pull guidemetothemoon/sprint-name-generator:[image_tag]
+docker run -dp 3006:80  guidemetothemoon/sprint-name-generator:[image_tag]
 ```
 
 ## Images

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,15 +1,3 @@
-FROM golang:alpine3.16
-
-COPY web/build /app/
-COPY go.mod /app/go.mod
-COPY go.sum /app/go.sum
-
-WORKDIR /app
-
-RUN apk add --no-cache git
-RUN go install github.com/shurcooL/goexec@latest
-RUN go get github.com/shurcooL/go-goon
-
+FROM nginx:latest
+COPY web/build /usr/share/nginx/html/
 EXPOSE 80
-
-CMD ["goexec", "http.ListenAndServe(`:80`, http.FileServer(http.Dir(`.`)))"]

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,6 +1,3 @@
-FROM nginx:latest
+FROM nginx:stable
 COPY web/build /usr/share/nginx/html/
-RUN apk add --update --no-cache 'libcurl>=7.84.0' && \
-    apk add --update --no-cache 'curl>=7.84.0' && \
-    apk add --update --no-cache 'libdb5.3>=5.3.28+dfsg1-0.9'
 EXPOSE 80

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,3 +1,6 @@
 FROM nginx:latest
 COPY web/build /usr/share/nginx/html/
+RUN apk add --update --no-cache 'libcurl>=7.84.0' && \
+    apk add --update --no-cache 'curl>=7.84.0' && \
+    apk add --update --no-cache 'libdb5.3>=5.3.28+dfsg1-0.9'
 EXPOSE 80

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:stable
 COPY web/build /usr/share/nginx/html/
+RUN apt-get --only-upgrade install curl
 EXPOSE 80

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,4 +1,3 @@
-FROM nginx:stable
+FROM nginx:1.23.1-alpine
 COPY web/build /usr/share/nginx/html/
-RUN apt-get --only-upgrade install curl
 EXPOSE 80


### PR DESCRIPTION
@flostadler, hey! I've added a few minor fixes related to scanning of container images for security vulnerabilities so it should work as expected now 😺
- Updated Container Scan GitHub Action to the newest version and added a workaround to resolve the known issue that caused build error. See following GitHub Issue for more information: https://github.com/Azure/container-scan/issues/146
- Also, latest and stable NGINX base image gets flagged by Container Scan with critical security vulnerabilities. Changed base image to 1.23.1-alpine which doesn't have these vulnerabilities present. Tested that Sprint Name Generator still works as expected.
