### PR TITLE
add randomizer seeding for unique pseudo-random numbers set

### DIFF
--- a/pkg/randomizer/randomizer.go
+++ b/pkg/randomizer/randomizer.go
@@ -2,7 +2,12 @@ package randomizer
 
 import (
 	"math/rand"
+	"time"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func GetRandom(values []string) string {
 	return values[rand.Intn(len(values))]


### PR DESCRIPTION
Since the `rand` is never seeded with a "random" number, the default seed value is used (i.e. `1`), which results in the same sequence of sprint names being generated after each page reload. Adding `rand.Seed()` call to the package initializer should fix the problem. 

I've used `time.Now().UnixNano()` as a seed number, but I'm open to any other options.